### PR TITLE
Ensure modprobe is available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN mkdir -p /conf
 RUN apt-get update && apt-get install -y \
   libgmp-dev \
   iptables \
-  xl2tpd
+  xl2tpd \
+  module-init-tools
 
 ENV STRONGSWAN_VERSION 5.3.4
 


### PR DESCRIPTION
Not entirely sure what the right answer is here but I found using this image on CoreOS I needed to add module-init-tools to ensure that modprobe was available otherwise I was getting modprobe not found errors and the container failed to start.

Also now starting the container with `-v /lib/modules:/lib/modules` and `--cap-add=ALL`
