### PR TITLE
User supervisord to handle the two processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install -y \
   libgmp-dev \
   iptables \
   xl2tpd \
-  module-init-tools
+  module-init-tools \
+  supervisor
 
 ENV STRONGSWAN_VERSION 5.5.0
 ENV GPG_KEY 948F158A4E76A27BF3D07532DF42C170B34DBA77
@@ -44,6 +45,10 @@ ADD strongswan.conf /etc/strongswan.conf
 # XL2TPD Configuration
 ADD xl2tpd.conf /etc/xl2tpd/xl2tpd.conf
 ADD options.xl2tpd /etc/ppp/options.xl2tpd
+
+# Supervisor config
+ADD supervisord.conf supervisord.conf
+ADD kill_supervisor.py /usr/bin/kill_supervisor.py
 
 ADD run.sh /run.sh
 ADD vpn_adduser /usr/local/bin/vpn_adduser

--- a/kill_supervisor.py
+++ b/kill_supervisor.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import sys
+import os
+import signal
+
+def write_stdout(s):
+   sys.stdout.write(s)
+   sys.stdout.flush()
+
+def write_stderr(s):
+   sys.stderr.write(s)
+   sys.stderr.flush()
+
+def main():
+   while 1:
+       write_stdout('READY\n')
+       line = sys.stdin.readline()
+       write_stdout('This line kills supervisor: ' + line);
+       try:
+               pidfile = open('/var/run/supervisord.pid','r')
+               pid = int(pidfile.readline());
+               os.kill(pid, signal.SIGQUIT)
+       except Exception as e:
+               write_stdout('Could not kill supervisor: ' + e.strerror + '\n')
+       write_stdout('RESULT 2\nOK')
+
+if __name__ == '__main__':
+   main()

--- a/run.sh
+++ b/run.sh
@@ -77,8 +77,6 @@ if [ -f "/etc/ipsec.d/xl2tpd.conf" ]; then
 	cp -f /etc/ipsec.d/xl2tpd.conf /etc/xl2tpd/xl2tpd.conf
 fi
 
-echo "Starting XL2TPD process..."
 mkdir -p /var/run/xl2tpd
-/usr/sbin/xl2tpd -c /etc/xl2tpd/xl2tpd.conf
 
-ipsec start --nofork\
+exec /usr/bin/supervisord -c /supervisord.conf

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,26 @@
+[supervisord]
+nodaemon=true
+
+[program:xl2tpd]
+command=/usr/sbin/xl2tpd -c /etc/xl2tpd/xl2tpd.conf -D
+redirect_stderr=true
+numprocs=1
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+[program:ipsec]
+command=ipsec start --nofork
+redirect_stderr=true
+numprocs=1
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+[eventlistener:ipsec_exit]
+command=/usr/bin/kill_supervisor.py
+process_name=ipsec
+events=PROCESS_STATE_FATAL
+
+[eventlistener:xl2tpd_exit]
+command=/usr/bin/kill_supervisor.py
+process_name=xl2tpd
+events=PROCESS_STATE_FATAL


### PR DESCRIPTION
The docker container consists for two processes: xl2tpd and ipsec. Previously,
the former was launched in the background and the latter was kept in the
foreground.

This has two issues:
   1. You can't gracefully stop the docker container anymore because none of the
      two processes receive the terminate signal from docker.

   2. If xl2tpd fails in the background, this goes unnoticed and the docker-container
      does not stop.

This commit replaces this behaviour: Supervisord is used to control the two
processes. If one of them fail, the whole docker container will fail. Also the
stdout and stderr is collected and aggregated and can therefor be viewed in the
docker logs.