### PR TITLE
Make run.sh executable after ADDing it to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ ADD supervisord.conf supervisord.conf
 ADD kill_supervisor.py /usr/bin/kill_supervisor.py
 
 ADD run.sh /run.sh
+RUN chmod +x /run.sh
 ADD vpn_adduser /usr/local/bin/vpn_adduser
 ADD vpn_deluser /usr/local/bin/vpn_deluser
 ADD vpn_setpsk /usr/local/bin/vpn_setpsk


### PR DESCRIPTION
Make run.sh executable after ADDing it to the docker image so entry command will work, instead of failing with 'permission denied' in certain cases